### PR TITLE
make postgis load less bad

### DIFF
--- a/stoqs/compose/local/stoqs/test.sh
+++ b/stoqs/compose/local/stoqs/test.sh
@@ -98,22 +98,22 @@ then
     psql -p $PGPORT -c "GRANT ALL ON ALL SEQUENCES IN SCHEMA public TO stoqsadm;" -U postgres -d stoqs
 
     echo "Copy x3dom javascript library version that works with SRC binary terrain"
-    mkdir static/x3dom-1.8.1
+    mkdir -p static/x3dom-1.8.1
     wget --no-check-certificate -O static/x3dom-1.8.1/x3dom-full.debug.js https://stoqs.mbari.org/static/x3dom-1.8.1/x3dom-full.debug.js
 
     # Get bathymetry and load data from MBARI data servers
-    wget --no-check-certificate -O loaders/Monterey25.grd https://stoqs.mbari.org/terrain/Monterey25.grd
-    coverage run --include="loaders/__in*,loaders/DAP*,loaders/Samp*" loaders/loadTestData.py
+    wget --no-check-certificate -O stoqs/loaders/Monterey25.grd https://stoqs.mbari.org/terrain/Monterey25.grd
+    coverage run --include="stoqs/loaders/__in*,stoqs/loaders/DAP*,stoqs/loaders/Samp*" stoqs/loaders/loadTestData.py
     if [ $? != 0 ]
     then
-        echo "loaders/loadTestData.py failed to load initial database; exiting test.sh."
+        echo "stoqs/loaders/loadTestData.py failed to load initial database; exiting test.sh."
         exit -1
     fi
 
-    coverage run --include="loaders/__in*,loaders/DAP*,loaders/Samp*" loaders/loadMoreData.py --append
+    coverage run --include="stoqs/loaders/__in*,stoqs/loaders/DAP*,stoqs/loaders/Samp*" stoqs/loaders/loadMoreData.py --append
     if [ $? != 0 ]
     then
-        echo "loaders/loadMoreData.py failed to load more data to existing Activity; exiting test.sh."
+        echo "stoqs/loaders/loadMoreData.py failed to load more data to existing Activity; exiting test.sh."
         exit -1
     fi
 

--- a/stoqs/requirements/base.txt
+++ b/stoqs/requirements/base.txt
@@ -84,3 +84,7 @@ transforms3d==0.4.1
 xarray==2023.1.0
 websocket-client==1.5.3
 whitenoise==6.5.0  # https://github.com/evansd/whitenoise
+
+## ADDING THINGS FOR LoadTestData.py
+django-coverage-plugin
+coverage[toml]


### PR DESCRIPTION
loadtestdata.py wasnt being called and it couldnt find monterey.grd 
First I fixed the paths to those files
then encountered some python dependency errors.
After adding those packages to the requirements files it looks like some data is being loaded into postgres
but the file errors out early with 
```
stoqs            | Traceback (most recent call last):
stoqs            |   File "/srv/stoqs/loaders/loadTestData.py", line 26, in <module>
stoqs            |     from CANON import CANONLoader
stoqs            |   File "/srv/stoqs/loaders/CANON/__init__.py", line 30, in <module>
stoqs            |     django.setup()
stoqs            |   File "/usr/local/lib/python3.10/dist-packages/django/__init__.py", line 24, in setup
stoqs            |     apps.populate(settings.INSTALLED_APPS)
stoqs            |   File "/usr/local/lib/python3.10/dist-packages/django/apps/registry.py", line 91, in populate
stoqs            |     app_config = AppConfig.create(entry)
stoqs            |   File "/usr/local/lib/python3.10/dist-packages/django/apps/config.py", line 193, in create
stoqs            |     import_module(entry)
stoqs            |   File "/usr/lib/python3.10/importlib/__init__.py", line 126, in import_module
stoqs            |     return _bootstrap._gcd_import(name[level:], package, level)
stoqs            | ModuleNotFoundError: No module named 'stoqs.users'
stoqs            | /usr/local/lib/python3.10/dist-packages/coverage/control.py:860: CoverageWarning: No data was collected. (no-data-collected)
stoqs            |   self._warn("No data was collected.", slug="no-data-collected")
stoqs            | stoqs/loaders/loadTestData.py failed to load initial database; exiting test.sh.
```
I dont know why/what is trying to load stoqs.users and it looks like the users directory properly has the __init__.py file

