### PR TITLE
add TEST env variable to force test.sh

### DIFF
--- a/stoqs/.env
+++ b/stoqs/.env
@@ -2,6 +2,7 @@
 #
 ## This variable enables debugpy listener in manage.py
 DEBUG=0
+TEST=0
 # Environment variables to be defined for a production deployment of STOQS.
 #
 # The initial default settings are sufficient to do a 'docker-compose up'
@@ -69,7 +70,6 @@ UWSGI_READ_TIMEOUT=300
 # - Change this to use another database server, e.g.: kraken.shore.mbari.org
 # - If a remote postgis server is used then the postgis service in docker-compose.yml should be removed
 STOQS_PGHOST=stoqs-postgis
-
 # Port that the STOQS_PGHOST serves its postgis database from, the default is 5432
 # - Change this if STOQS_PGHOST serves postgis from a different port, e.g.: 5433
 STOQS_PGHOST_PORT=5432

--- a/stoqs/compose/local/stoqs/stoqs-start.sh
+++ b/stoqs/compose/local/stoqs/stoqs-start.sh
@@ -46,7 +46,7 @@ chmod 777 ${MAPFILE_DIR}
 # If default stoqs database doesn't exist then load it - also running the unit and functional tests
 echo "Checking for presence of stoqs database..."
 POSTGRES_DB=stoqs python ${STOQS_SRVHOME}/compose/local/stoqs/database-check.py
-if [[ $? != 0 ]]; then
+if [[ $? != 0 ]]  || [[ $TEST -eq 1 ]]; then
     echo "Creating default stoqs database and running tests..."
     ./test.sh ${POSTGRES_PASSWORD} load noextraload
 fi


### PR DESCRIPTION
Not necessary but thought this might allow you to simplify the run `test.sh` steps. If you change the `TEST` variable in .env it will force the start-stoqs to go ahead and run `test.sh` even if the database has already been loaded